### PR TITLE
fix(prisma): fixed missing name for `filiere` and `domaine` model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .pnp.js
 
 prisma/dev.db
+prisma/*.db-journal
 
 # testing
 /coverage

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,7 @@ model Organisation {
 
 model Filiere {
   id             Int          @id @default(autoincrement())
+  nom            String
   organisation   Organisation @relation(fields: [organisationId], references: [id])
   organisationId Int
   domaines       Domaine[]
@@ -25,6 +26,7 @@ model Filiere {
 
 model Domaine {
   id            Int          @id @default(autoincrement())
+  nom           String
   filiere       Filiere      @relation(fields: [filiereId], references: [id])
   filiereId     Int
   expertises    Expertise[]


### PR DESCRIPTION
Ce correctif implémente deux champs manquants dans la base de données :

1. Le champ `nom` dans la table `Filiere`
2. Le champ `nom` dans la table `Domaine`